### PR TITLE
pull in latest changes, change another "we" to "you"

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ Then, you install some records in your newly created table using `JdbcTemplate`'
 
 > **Note:** Using `?` for arguments avoids [SQL injection attacks](http://en.wikipedia.org/wiki/SQL_injection) by instructing JDBC to bind variables.
 
-Finally you use the `query` method to search your table for records matching the criteria. You again use the "`?`" arguments to create parameters for the query, passing in the actual values when you make the call. The last argument in the `query` method is an instance of `RowMapper<T>`, which we provide. Spring's done 90% of the work, but it can't know what you want it to do with the result set data. So, you provide a `RowMapper<T>` instance that Spring will call for each record, aggregate the results, and return as a collection. 
+Finally you use the `query` method to search your table for records matching the criteria. You again use the "`?`" arguments to create parameters for the query, passing in the actual values when you make the call. The last argument in the `query` method is an instance of `RowMapper<T>`, which you provide. Spring's done 90% of the work, but it can't know what you want it to do with the result set data. So, you provide a `RowMapper<T>` instance that Spring will call for each record, aggregate the results, and return as a collection. 
 
 ## {!snippet:build-an-executable-jar}
 


### PR DESCRIPTION
In "The last argument in the `query` method is an instance of
`RowMapper<T>`, which we provide" changed "we" to "you" to clarify it is
the user and not Spring which provides this; per guidelines use "you" to
refer to user action.
