### PR TITLE
Use starter-jdbc, and not spring-jdbc

### DIFF
--- a/complete/pom.xml
+++ b/complete/pom.xml
@@ -24,7 +24,7 @@
         </dependency>
         <dependency>
             <groupId>org.springframework</groupId>
-            <artifactId>spring-jdbc</artifactId>
+            <artifactId>spring-boot-starter-jdbc</artifactId>
         </dependency>
         <dependency>
             <groupId>com.h2database</groupId>


### PR DESCRIPTION
JdbcTemplate/Datasource/NamedParameterJdbcTemplate are not autowired unless the artifact id is spring-boot-starter-jdbc
