### PR TITLE
URL Cleanup

### DIFF
--- a/LICENSE.writing.txt
+++ b/LICENSE.writing.txt
@@ -1,1 +1,1 @@
-Except where otherwise noted, this work is licensed under http://creativecommons.org/licenses/by-nd/3.0/
+Except where otherwise noted, this work is licensed under https://creativecommons.org/licenses/by-nd/3.0/

--- a/README.adoc
+++ b/README.adoc
@@ -64,7 +64,7 @@ Then you install some records in your newly created table using `JdbcTemplate`'s
 
 NOTE: For single insert statements, `JdbcTemplate`'s `insert` method is good. But for multiple inserts, it's better to use `batchUpdate`.
 
-NOTE: Use `?` for arguments to avoid http://en.wikipedia.org/wiki/SQL_injection[SQL injection attacks] by instructing JDBC to bind variables.
+NOTE: Use `?` for arguments to avoid https://en.wikipedia.org/wiki/SQL_injection[SQL injection attacks] by instructing JDBC to bind variables.
 
 Finally you use the `query` method to search your table for records matching the criteria. You again use the "`?`" arguments to create parameters for the query, passing in the actual values when you make the call. The last argument is a Java 8 lambda used to convert each result row into a new `Customer` object.
 
@@ -91,7 +91,7 @@ You should see the following output:
 == Summary
 Congratulations! You've just used Spring to develop a simple JDBC client.
 
-NOTE: Spring Boot has many features for configuring and customizing the connection pool, for instance to connect to an external database instead of an in-memory one. Please refer to the http://docs.spring.io/spring-boot/docs/2.1.3.RELEASE/reference/htmlsingle/#boot-features-configure-datasource[User Guide] for more detail.
+NOTE: Spring Boot has many features for configuring and customizing the connection pool, for instance to connect to an external database instead of an in-memory one. Please refer to the https://docs.spring.io/spring-boot/docs/2.1.3.RELEASE/reference/htmlsingle/#boot-features-configure-datasource[User Guide] for more detail.
 
 == See Also
 


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://creativecommons.org/licenses/by-nd/3.0/ with 1 occurrences migrated to:  
  https://creativecommons.org/licenses/by-nd/3.0/ ([https](https://creativecommons.org/licenses/by-nd/3.0/) result 200).
* [ ] http://en.wikipedia.org/wiki/SQL_injection with 1 occurrences migrated to:  
  https://en.wikipedia.org/wiki/SQL_injection ([https](https://en.wikipedia.org/wiki/SQL_injection) result 200).
* [ ] http://docs.spring.io/spring-boot/docs/2.1.3.RELEASE/reference/htmlsingle/ with 1 occurrences migrated to:  
  https://docs.spring.io/spring-boot/docs/2.1.3.RELEASE/reference/htmlsingle/ ([https](https://docs.spring.io/spring-boot/docs/2.1.3.RELEASE/reference/htmlsingle/) result 301).