### PR TITLE
Changing the use of depreacted method

### DIFF
--- a/complete/src/main/java/com/example/relationaldataaccess/RelationalDataAccessApplication.java
+++ b/complete/src/main/java/com/example/relationaldataaccess/RelationalDataAccessApplication.java
@@ -46,8 +46,8 @@ public class RelationalDataAccessApplication implements CommandLineRunner {
 
 		log.info("Querying for customer records where first_name = 'Josh':");
 		jdbcTemplate.query(
-				"SELECT id, first_name, last_name FROM customers WHERE first_name = ?", new Object[] { "Josh" },
-				(rs, rowNum) -> new Customer(rs.getLong("id"), rs.getString("first_name"), rs.getString("last_name"))
-		).forEach(customer -> log.info(customer.toString()));
+				"SELECT id, first_name, last_name FROM customers WHERE first_name = ?",
+				(rs, rowNum) -> new Customer(rs.getLong("id"), rs.getString("first_name"), rs.getString("last_name")), "Josh")
+		.forEach(customer -> log.info(customer.toString()));
 	}
 }


### PR DESCRIPTION
Hello.

I changed method usage where deprecated warnings are exposed.

* JdbcTemplate's Deprecated Method
```java
  @Deprecated
  @Override
  public <T> List<T> query(String sql, @Nullable Object[] args, RowMapper<T> rowMapper) throws DataAccessException {
  ...
```

* JdbcTemplate's normal method
```java
  @Override
  public <T> List<T> query(String sql, RowMapper<T> rowMapper, @Nullable Object... args) {
  ...
```

thank you have a good day. 😄